### PR TITLE
Receive argument in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker build -t manemonetech/ml-base .
+docker build $@ -t manemonetech/ml-base .


### PR DESCRIPTION
Sometimes we need to pass extra arguments to `docker build` command.
e.g: `--no-cache`